### PR TITLE
Add openjdk to the dependencies.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ scripting api uses protocol buffers for server/client communication so both the
 Python client and the server need the protocol buffer libraries and protoc
 compiler to generate source.)
 
-Install Maven and the protobuf compiler:
+Install Maven, the protobuf compiler and openjdk:
 ```
-sudo apt-get install maven ant protobuf-compiler
+sudo apt-get install maven ant protobuf-compiler openjdk-7-jdk
 ```
 
 


### PR DESCRIPTION
Just to avoid that:

`````` text
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:2.0.2:compile (default-compile) on project RoboMinionsPlugin: Compilation failure
[ERROR] Unable to locate the Javac Compiler in:
[ERROR] /usr/lib/jvm/java-7-openjdk-amd64/jre/../lib/tools.jar
[ERROR] Please ensure you are using JDK 1.4 or above and
[ERROR] not a JRE (the com.sun.tools.javac.Main class is required).
[ERROR] In most cases you can change the location of your Java
[ERROR] installation by setting the JAVA_HOME environment variable.
[ERROR] -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException```
``````
